### PR TITLE
Create a log file for report messages

### DIFF
--- a/base.py
+++ b/base.py
@@ -630,6 +630,7 @@ class MBDynSelectOutputFile(bpy.types.Operator, ImportHelper):
                 get_plot_vars_glob(self, context)
             except NameError:
                 message = "NetCDF module not imported correctly"
+
                 self.report({'ERROR'}, message)
                 baseLogger.error(message)
                 return {'CANCELLED'}
@@ -653,8 +654,8 @@ class MBDynAssignLabels(bpy.types.Operator):
     def execute(self, context):
         ret_val = assign_labels(context)
         if ret_val == {'NOTHING_DONE'}:
-            message = "MBDyn labels file provided appears to not contain \
-            correct labels."
+            message = 'MBDyn labels file provided appears to not contain ' +\
+            'correct labels.'
             self.report({'WARNING'}, message)
             baseLogger.warning(message)
             return {'CANCELLED'}
@@ -1110,8 +1111,9 @@ class Scene_OT_MBDyn_Node_Import_All(bpy.types.Operator):
         for node in nd:
             if (mbs.min_node_import <= node.int_label) & (mbs.max_node_import >= node.int_label):
                 if not(spawn_node_obj(context, node)):
-                    message = "Could not spawn the Blender object assigned to node " \
-                            + str(node.int_label)
+                    message = "Could not spawn the Blender object assigned to node {}"\
+                            .format(node.int_label)
+
                     self.report({'ERROR'}, message)
                     baseLogger.error(message)
                     return {'CANCELLED'}
@@ -1161,8 +1163,9 @@ class Scene_OT_MBDyn_Node_Import_Single(bpy.types.Operator):
         for node in context.scene.mbdyn.nodes:
             if node.int_label == self.int_label:
                 if not(spawn_node_obj(context, node)):
-                    message = "Could not spawn the Blender object assigned to node " \
-                            + str(node.int_label)
+                    message = "Could not spawn the Blender object assigned to node {}"\
+                            .format(node.int_label)
+
                     self.report({'ERROR'}, message)
                     baseLogger.error(message)
                     return {'CANCELLED'}
@@ -1210,6 +1213,7 @@ class Scene_OT_MBDyn_Import_Elements_by_Type(bpy.types.Operator):
                     eval("spawn_" + elem.type + "_element(elem, context)")
                 except NameError:
                     message = "Couldn't find the element import function"
+
                     self.report({'ERROR'}, message)
                     baseLogger.error(message)
                     return {'CANCELLED'}
@@ -1238,7 +1242,8 @@ class MBDynOBJNodeSelectButton(bpy.types.Operator):
 
             if ret_val == 'ROT_NOT_SUPPORTED':
                 message = "Rotation parametrization not supported, node " \
-                            + obj.mbdyn.string_label
+                + obj.mbdyn.string_label
+
                 self.report({'ERROR'}, message)
                 baseLogger.error(message)
 

--- a/base.py
+++ b/base.py
@@ -32,6 +32,8 @@ from bpy.props import *
 from bpy.app.handlers import persistent
 from bpy_extras.io_utils import ImportHelper
 
+import logging
+
 from mathutils import *
 from math import *
 
@@ -515,26 +517,46 @@ class MBDynReadLog(bpy.types.Operator):
 
         missing = context.scene.mbdyn.missing
         if len(obj_names) > 0:
-            self.report({'WARNING'}, "Some of the nodes/elements are missing in the new .log file")
+            message = "Some of the nodes/elements are missing in the new .log file"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             hide_or_delete(obj_names, missing)
             return {'FINISHED'}
+
         if ret_val == {'LOG_NOT_FOUND'}:
-            self.report({'ERROR'}, "MBDyn .log file not found")
+            message = "MBDyn .log file not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
+
         elif ret_val == {'NODES_NOT_FOUND'}:
-            self.report({'ERROR'}, "The .log file selected does not contain MBDyn nodes definitions")
+            message = "The .log file selected does not contain MBDyn nodes definitions"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
+
         elif ret_val == {'MODEL_INCONSISTENT'}:
-            self.report({'WARNING'}, "Contents of MBDyn .log file inconsistent with the scene")
+            message = "Contents of MBDyn .log file inconsistent with the scene"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'FINISHED'}
+
         elif ret_val == {'NODES_INCONSISTENT'}:
-            self.report({'WARNING'}, "Nodes in MBDyn .log file inconsistent with the scene")
+            message = "Nodes in MBDyn .log file inconsistent with the scene"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'FINISHED'}
+
         elif ret_val == {'ELEMS_INCONSISTENT'}:
-            self.report({'WARNING'}, "Elements in MBDyn .log file inconsistent with the scene")
+            message = "Elements in MBDyn .log file inconsistent with the scene"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'FINISHED'}
+
         elif ret_val == {'FINISHED'}:
-            self.report({'INFO'}, "MBDyn entities imported successfully") 
+            message = "MBDyn entities imported successfully"
+            self.report({'INFO'}, message) 
+            logging.info(message)
             return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -561,6 +583,13 @@ class MBDynSelectOutputFile(bpy.types.Operator, ImportHelper):
         remove_oldframes(context)
 
         mbs.file_path, mbs.file_basename = path_leaf(self.filepath)
+
+        formatter = '%(asctime)s - %(levelname)s - %(message)s'
+        logFile = mbs.file_path + mbs.file_basename + '.err'
+        logging.basicConfig(level=logging.DEBUG, format=formatter,
+                    datefmt='%a, %d %b %Y %H:%M:%S',
+                    filename=logFile)
+
         if self.filepath[-2:] == 'nc':
             try:
                 nc = Dataset(self.filepath, "r", format="NETCDF3")
@@ -583,7 +612,9 @@ class MBDynSelectOutputFile(bpy.types.Operator, ImportHelper):
 
                 get_plot_vars_glob(self, context)
             except NameError:
-                self.report({'ERROR'}, "NetCDF module not imported correctly")
+                message = "NetCDF module not imported correctly"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
         else:
             mbs.num_rows = file_len(self.filepath)
@@ -605,14 +636,22 @@ class MBDynAssignLabels(bpy.types.Operator):
     def execute(self, context):
         ret_val = assign_labels(context)
         if ret_val == {'NOTHING_DONE'}:
-            self.report({'WARNING'}, "MBDyn labels file provided appears to not contain \
-                    correct labels.")
+            message = "MBDyn labels file provided appears to not contain \
+                    correct labels."
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'CANCELLED'}
+
         elif ret_val == {'LABELS_UPDATED'}:
-            self.report({'INFO'}, "MBDyn labels imported")
+            message = "MBDyn labels imported"
+            self.report({'INFO'}, message)
+            logging.info(message)
             return {'FINISHED'}
+
         elif ret_val == {'FILE_NOT_FOUND'}:
-            self.report({'ERROR'}, "MBDyn labels file not found...")
+            message = "MBDyn labels file not found..."
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 
     def invoke(self, context, event):
@@ -630,7 +669,9 @@ class MBDynClearData(bpy.types.Operator):
     def execute(self, context):
         context.scene.mbdyn.nodes.clear()
         context.scene.mbdyn.elems.clear()
-        self.report({'INFO'}, "Scene MBDyn data cleared.")
+        message = "Scene MBDyn data cleared."
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -650,7 +691,9 @@ class MBDynSetMotionPaths(bpy.types.Operator):
         else:
             ret_val = set_motion_paths_netcdf(context)
         if ret_val == 'CANCELLED':
-            self.report({'WARNING'}, "MBDyn results file not loaded") 
+            message = "MBDyn results file not loaded"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
         return ret_val
     
     def invoke(self, context, event):
@@ -1050,8 +1093,10 @@ class Scene_OT_MBDyn_Node_Import_All(bpy.types.Operator):
         for node in nd:
             if (mbs.min_node_import <= node.int_label) & (mbs.max_node_import >= node.int_label):
                 if not(spawn_node_obj(context, node)):
-                    self.report({'ERROR'}, "Could not spawn the Blender object assigned to node " \
-                            + str(node.int_label))
+                    message = "Could not spawn the Blender object assigned to node " \
+                            + str(node.int_label)
+                    self.report({'ERROR'}, message)
+                    logging.error(message)
                     return {'CANCELLED'}
 
                 obj = context.scene.objects.active
@@ -1072,10 +1117,14 @@ class Scene_OT_MBDyn_Node_Import_All(bpy.types.Operator):
                 added_nodes += 1
         
         if added_nodes:
-            self.report({'INFO'}, "All MBDyn nodes imported successfully")
+            message = "All MBDyn nodes imported successfully"
+            self.report({'INFO'}, message)
+            logging.info(message)
             return {'FINISHED'}
         else:
-            self.report({'WARNING'}, "No MBDyn nodes imported")
+            message = "No MBDyn nodes imported"
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Node_Import_All class
@@ -1095,8 +1144,10 @@ class Scene_OT_MBDyn_Node_Import_Single(bpy.types.Operator):
         for node in context.scene.mbdyn.nodes:
             if node.int_label == self.int_label:
                 if not(spawn_node_obj(context, node)):
-                    self.report({'ERROR'}, "Could not spawn the Blender object assigned to node " \
-                            + str(node.int_label))
+                    message = "Could not spawn the Blender object assigned to node " \
+                            + str(node.int_label)
+                    self.report({'ERROR'}, message)
+                    logging.error(message)
                     return {'CANCELLED'}
                 obj = context.scene.objects.active
                 obj.mbdyn.type = 'node.struct'
@@ -1115,10 +1166,14 @@ class Scene_OT_MBDyn_Node_Import_Single(bpy.types.Operator):
                 print("MBDynNodeAddButton: added node " + str(node.int_label) + " to scene and associated with object " + obj.name)
                 added_node = True
         if added_node:
-            self.report({'INFO'}, "MBDyn node " + node.string_label + " imported to scene.")
+            message = "MBDyn node " + node.string_label + " imported to scene."
+            self.report({'INFO'}, message)
+            logging.info(message)
             return {'FINISHED'}
         else:
-            self.report({'WARNING'}, "Cannot import MBDyn node " + node.string_label + ".") 
+            message = "Cannot import MBDyn node " + node.string_label + "."
+            self.report({'WARNING'}, message) 
+            logging.warning(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Node_Import_Single class
@@ -1137,7 +1192,9 @@ class Scene_OT_MBDyn_Import_Elements_by_Type(bpy.types.Operator):
                 try:
                     eval("spawn_" + elem.type + "_element(elem, context)")
                 except NameError:
-                    self.report({'ERROR'}, "Couldn't find the element import function")
+                    message = "Couldn't find the element import function"
+                    self.report({'ERROR'}, message)
+                    logging.error(message)
                     return {'CANCELLED'}
         return {'FINISHED'}
 # -----------------------------------------------------------
@@ -1161,9 +1218,13 @@ class MBDynOBJNodeSelectButton(bpy.types.Operator):
             if self.int_label == item.int_label:
                 item.blender_object = context.object.name
                 ret_val = update_parametrization(context.object)
+
             if ret_val == 'ROT_NOT_SUPPORTED':
-                self.report({'ERROR'}, "Rotation parametrization not supported, node " \
-                            + obj.mbdyn.string_label)
+                message = "Rotation parametrization not supported, node " \
+                            + obj.mbdyn.string_label
+                self.report({'ERROR'}, message)
+                logging.error(message)
+
             else:
                 # DEBUG message to console
                 print("Object " + context.object.name + \
@@ -1247,7 +1308,9 @@ class MBDynCreateVerticesFromNodesButton(bpy.types.Operator):
                 bpy.ops.object.select_all()
 
         else:
-            self.report({'WARNING'}, "No MBDyn nodes associated with selected objects.")
+            message = "No MBDyn nodes associated with selected objects."
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return{'CANCELLED'}
 
         return{'FINISHED'}

--- a/base.py
+++ b/base.py
@@ -619,7 +619,7 @@ def blend_log(scene):
     mbs = bpy.context.scene.mbdyn
 
     if mbs.file_path:
-        log_messages(mbs, baseLogger)
+        log_messages(mbs, baseLogger, False)
 
 bpy.app.handlers.load_post.append(blend_log)
 
@@ -631,7 +631,9 @@ def rename_log(scene):
     newLog = ('{0}_{1}.bylog').format(mbs.file_path + newBlend, mbs.file_basename)
     os.rename(logFile, newLog)
 
-    log_messages(mbs, baseLogger)
+    bpy.data.texts[os.path.basename(logFile)].name = os.path.basename(newLog)
+
+    log_messages(mbs, baseLogger, True)
 
 bpy.app.handlers.save_post.append(rename_log)
 
@@ -714,7 +716,7 @@ class MBDynSelectOutputFile(bpy.types.Operator, ImportHelper):
         mbs.file_path, mbs.file_basename = path_leaf(self.filepath)
 
         baseLogger.handlers = []
-        log_messages(mbs, baseLogger)
+        log_messages(mbs, baseLogger, False)
 
         if self.filepath[-2:] == 'nc':
             try:

--- a/base.py
+++ b/base.py
@@ -585,7 +585,7 @@ class MBDynSelectOutputFile(bpy.types.Operator, ImportHelper):
         mbs.file_path, mbs.file_basename = path_leaf(self.filepath)
 
         formatter = '%(asctime)s - %(levelname)s - %(message)s'
-        logFile = mbs.file_path + mbs.file_basename + '.err'
+        logFile = mbs.file_path + mbs.file_basename + '.bylog'
         logging.basicConfig(level=logging.DEBUG, format=formatter,
                     datefmt='%a, %d %b %Y %H:%M:%S',
                     filename=logFile)

--- a/baselib.py
+++ b/baselib.py
@@ -619,3 +619,14 @@ def log_messages(mbs, baseLogger):
         baseLogger.addHandler(custom)
 
         bpy.data.texts.new(os.path.basename(logFile))
+
+def delete_log():
+    mbs = bpy.context.scene.mbdyn
+
+    if not bpy.data.is_saved:
+        os.remove(logFile)
+
+    elif mbs.del_log:
+        os.remove(logFile)
+
+atexit.register(delete_log)

--- a/baselib.py
+++ b/baselib.py
@@ -533,9 +533,12 @@ def log_messages(mbs, baseLogger):
         blendFile = os.path.splitext(blendFile)[0]
 
         formatter = '%(asctime)s - %(levelname)s - %(message)s'
+        datefmt = '%m/%d/%Y %I:%M:%S %p'
         logFile = ('{0}_{1}.bylog').format(mbs.file_path + blendFile, mbs.file_basename)
 
         fh = logging.FileHandler(logFile)
-        fh.setFormatter(logging.Formatter(formatter))
+        fh.setFormatter(logging.Formatter(formatter, datefmt))
 
         baseLogger.addHandler(fh)
+
+        bpy.ops.text.open(filepath = logFile)

--- a/baselib.py
+++ b/baselib.py
@@ -35,9 +35,7 @@ from bpy_extras.io_utils import ImportHelper
 import logging
 
 import numpy as np
-
-import ntpath, os, csv, math
-
+import ntpath, os, csv, math, atexit
 from collections import namedtuple
 
 from .nodelib import *
@@ -596,6 +594,11 @@ def set_motion_paths_netcdf(context):
 
 # -----------------------------------------------------------
 # end of set_motion_paths_netcdf() function 
+class BlenderHandler(logging.Handler):
+    def emit(self, record):
+        log_entry = self.format(record)
+        editor = bpy.data.texts[os.path.basename(logFile)]
+        editor.write(log_entry + '\n')
 
 def log_messages(mbs, baseLogger):
 
@@ -605,11 +608,14 @@ def log_messages(mbs, baseLogger):
 
         formatter = '%(asctime)s - %(levelname)s - %(message)s'
         datefmt = '%m/%d/%Y %I:%M:%S %p'
+        global logFile
         logFile = ('{0}_{1}.bylog').format(mbs.file_path + blendFile, mbs.file_basename)
 
         fh = logging.FileHandler(logFile)
         fh.setFormatter(logging.Formatter(formatter, datefmt))
 
+        custom = BlenderHandler()
         baseLogger.addHandler(fh)
+        baseLogger.addHandler(custom)
 
-        bpy.ops.text.open(filepath = logFile)
+        bpy.data.texts.new(os.path.basename(logFile))

--- a/baselib.py
+++ b/baselib.py
@@ -600,7 +600,7 @@ class BlenderHandler(logging.Handler):
         editor = bpy.data.texts[os.path.basename(logFile)]
         editor.write(log_entry + '\n')
 
-def log_messages(mbs, baseLogger):
+def log_messages(mbs, baseLogger, saved_blend):
 
         blendFile = os.path.basename(bpy.data.filepath) if bpy.data.is_saved \
                     else 'untitled.blend'
@@ -615,10 +615,13 @@ def log_messages(mbs, baseLogger):
         fh.setFormatter(logging.Formatter(formatter, datefmt))
 
         custom = BlenderHandler()
+        custom.setFormatter(logging.Formatter(formatter, datefmt))
+
         baseLogger.addHandler(fh)
         baseLogger.addHandler(custom)
 
-        bpy.data.texts.new(os.path.basename(logFile))
+        if not saved_blend:
+            bpy.data.texts.new(os.path.basename(logFile))
 
 def delete_log():
     mbs = bpy.context.scene.mbdyn

--- a/baselib.py
+++ b/baselib.py
@@ -31,6 +31,8 @@ from bpy.types import Operator, Panel
 from bpy.props import *
 from bpy_extras.io_utils import ImportHelper
 
+import logging
+
 import ntpath, os, csv, math
 from collections import namedtuple
 
@@ -277,12 +279,20 @@ def update_label(self, context):
                 ret_val = update_parametrization(obj)
 
             if ret_val == 'ROT_NOT_SUPPORTED':
-                self.report({'ERROR'}, "Rotation parametrization not supported, node " \
-                + obj.mbdyn.string_label)
+                message = "Rotation parametrization not supported, node " \
+                + obj.mbdyn.string_label
+                self.report({'ERROR'}, message)
+                logging.error(message)
+
             elif ret_val == 'LOG_NOT_FOUND':
-                self.report({'ERROR'}, "MBDyn .log file not found")
+                message = "MBDyn .log file not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
+
         except KeyError:
-            self.report({'ERROR'}, "Node not found")
+            message = "Node not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             pass
     return
 # -----------------------------------------------------------

--- a/baselib.py
+++ b/baselib.py
@@ -26,6 +26,8 @@
 from mathutils import *
 from math import *
 
+import os
+
 import bpy
 from bpy.types import Operator, Panel
 from bpy.props import *
@@ -318,7 +320,7 @@ def remove_oldframes(context):
 
 def hide_or_delete(obj_names, missing):
 
-    obj_list = [bpy.data.objects[var] for var in obj_names]
+    obj_names = list(filter(lambda v: v != 'none', obj_names))
     obj_list = [bpy.data.objects[var] for var in obj_names]
 
     if missing == "HIDE":
@@ -523,3 +525,15 @@ def set_motion_paths_netcdf(context):
 
 # -----------------------------------------------------------
 # end of set_motion_paths_netcdf() function 
+
+def log_messages(mbs, baseLogger):
+
+        blendFile = os.path.basename(bpy.data.filepath) if bpy.data.is_saved \
+                    else 'untitled.blend'
+        formatter = ('%(asctime)s - %(levelname)s - {} - %(message)s').format(blendFile)
+        logFile = mbs.file_path + mbs.file_basename + '.bylog'
+
+        fh = logging.FileHandler(logFile)
+        fh.setFormatter(logging.Formatter(formatter))
+
+        baseLogger.addHandler(fh)

--- a/baselib.py
+++ b/baselib.py
@@ -530,8 +530,10 @@ def log_messages(mbs, baseLogger):
 
         blendFile = os.path.basename(bpy.data.filepath) if bpy.data.is_saved \
                     else 'untitled.blend'
-        formatter = ('%(asctime)s - %(levelname)s - {} - %(message)s').format(blendFile)
-        logFile = mbs.file_path + mbs.file_basename + '.bylog'
+        blendFile = os.path.splitext(blendFile)[0]
+
+        formatter = '%(asctime)s - %(levelname)s - %(message)s'
+        logFile = ('{0}_{1}.bylog').format(mbs.file_path + blendFile, mbs.file_basename)
 
         fh = logging.FileHandler(logFile)
         fh.setFormatter(logging.Formatter(formatter))

--- a/beamlib.py
+++ b/beamlib.py
@@ -717,22 +717,21 @@ class Scene_OT_MBDyn_Elems_Import_Beam2(bpy.types.Operator):
             elem = ed['beam2_' + str(self.int_label)]
             retval = spawn_beam2_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                message = "Found the Object " + \
-                    elem.blender_object + \
+                message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
                 self.report({'WARNING'}, message)
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object" + \
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object" + \
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -771,21 +770,21 @@ class Scene_OT_MBDyn_Elems_Import_Beam3(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE3_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[2].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[2].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/beamlib.py
+++ b/beamlib.py
@@ -26,6 +26,8 @@ import bpy
 import numpy as np
 import csv
 
+import logging
+
 from mathutils import *
 from math import *
 
@@ -687,7 +689,9 @@ def update_beam3(elem, insert_keyframe = False):
             if 'context is incorrect' in str(err):
                 pass
             else:
-                self.report({'WARNING'}, str(err))
+                message = str(err)
+                self.report({'WARNING'}, message)
+                logging.warning(message)
         except TypeError:
             pass
 
@@ -713,25 +717,32 @@ class Scene_OT_MBDyn_Elems_Import_Beam2(bpy.types.Operator):
             elem = ed['beam2_' + str(self.int_label)]
             retval = spawn_beam2_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
+                message = "Found the Object " + \
                     elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
 
         except KeyError:
-            self.report({'ERROR'}, "Element beam2_" + str(elem.int_label) + "not found.")
+            message = "Element beam2_" + str(elem.int_label) + "not found."
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
             
         return {'FINISHED'}
@@ -754,29 +765,37 @@ class Scene_OT_MBDyn_Elems_Import_Beam3(bpy.types.Operator):
             elem = ed['beam3_' + str(self.int_label)]
             retval = spawn_beam3_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE3_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[2].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[2].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
 
         except KeyError:
-            self.report({'ERROR'}, "Element beam3_" + str(elem.int_label) + "not found.")
+            message = "Element beam3_" + str(elem.int_label) + "not found."
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
             
 # -----------------------------------------------------------
@@ -792,7 +811,9 @@ class Object_OT_MBDyn_update_beam3(bpy.types.Operator):
         ed = context.scene.mbdyn.elems
         ret_val = update_beam3(ed[context.object.name])
         if ret_val == 'OBJECTS_NOTFOUND':
-            self.report({'ERROR'}, "Unable to find Blender objects needed")
+            message = "Unable to find Blender objects needed"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
         else:
             return ret_val

--- a/bodylib.py
+++ b/bodylib.py
@@ -179,15 +179,15 @@ class Scene_OT_MBDyn_Import_Body_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -195,7 +195,7 @@ class Scene_OT_MBDyn_Import_Body_Element(bpy.types.Operator):
                 return retval
         except KeyError:
             message = "Element body_" + str(elem.int_label) + "not found"
-            self.report({'ERROR'}, mes)
+            self.report({'ERROR'}, message)
             logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------

--- a/bodylib.py
+++ b/bodylib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -171,24 +173,30 @@ class Scene_OT_MBDyn_Import_Body_Element(bpy.types.Operator):
             elem = ed['body_' + str(self.int_label)]
             retval = spawn_body_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element body_" + str(elem.int_label) + "not found")
+            message = "Element body_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, mes)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Body_Element class

--- a/carjlib.py
+++ b/carjlib.py
@@ -327,28 +327,31 @@ class Scene_OT_MBDyn_Import_Cardano_Hinge_Joint_Element(bpy.types.Operator):
             retval = spawn_cardano_hinge_element(elem, context)
 
             if retval == 'OBJECT_EXISTS':
-                message = "Found the Object " + \
-                    elem.blender_object + \
+                message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
+
                 self.report({'WARNING'}, message)
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
+
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
+
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " + \
+                        "load library object"
+
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -384,19 +387,22 @@ class Scene_OT_MBDyn_Import_Cardano_Pin_Joint_Element(bpy.types.Operator):
             if retval == 'OBJECT_EXISTS':
                 message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
+
                 self.report({'WARNING'}, message)
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object" +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
+
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
+
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/carjlib.py
+++ b/carjlib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -325,28 +327,37 @@ class Scene_OT_MBDyn_Import_Cardano_Hinge_Joint_Element(bpy.types.Operator):
             retval = spawn_cardano_hinge_element(elem, context)
 
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
+                message = "Found the Object " + \
                     elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element revolute_hinge_" + str(elem.int_label) + "not found")
+            message = "Element revolute_hinge_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Cardano_Joint_Element class
@@ -371,24 +382,30 @@ class Scene_OT_MBDyn_Import_Cardano_Pin_Joint_Element(bpy.types.Operator):
             retval = spawn_cardano_pin_element(elem, context)
             
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element cardano_pin_" + str(elem.int_label) + "not found")
+            message = "Element cardano_pin_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Cardano_Joint_Element class

--- a/clampjlib.py
+++ b/clampjlib.py
@@ -191,15 +191,15 @@ class Scene_OT_MBDyn_Import_Clamp_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/clampjlib.py
+++ b/clampjlib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -183,24 +185,30 @@ class Scene_OT_MBDyn_Import_Clamp_Joint_Element(bpy.types.Operator):
             elem = ed['clamp_' + str(self.int_label)]
             retval = spawn_clamp_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element clamp_" + str(elem.int_label) + "not found")
+            message = "Element clamp_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Clamp_Joint_Element class

--- a/defdispjlib.py
+++ b/defdispjlib.py
@@ -24,6 +24,8 @@
 
 import bpy
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -118,7 +120,10 @@ class Scene_OT_MBDyn_Import_Deformable_Displacement_Joint_Element(bpy.types.Oper
             elem = ed['defdispj_' + str(self.int_label)]
             return spawn_defdispj_element(elem, context)
         except KeyError:
-            self.report({'ERROR'}, "Element deformable_displacement_" + str(elem.int_label) + "not found")
+            message = "Element deformable_displacement_" + str(elem.int_label) \
+                   + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Deformable_Displacement_Element class

--- a/eigenlib.py
+++ b/eigenlib.py
@@ -29,6 +29,8 @@ import numpy as np
 from bpy.types import Operator, Panel
 from bpy.props import IntProperty, FloatProperty
 
+import logging
+
 from .nodelib import axes
 
 import pdb
@@ -152,7 +154,9 @@ class Tools_OT_MBDyn_Eigen_Geometry(bpy.types.Operator):
                 anim_nodes.append(node.name)
 
         if not(anim_nodes):
-            self.report({'ERROR'}, "Import nodes first")
+            message = "Import nodes first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
     
         for ndx in anim_nodes:
@@ -191,7 +195,9 @@ class Tools_OT_MBDyn_Eigen_Geometry(bpy.types.Operator):
             else:
                 # Should not be reached
                 print("ops.mbdyn_eig_geometry: Error: unrecognised rotation parametrization")
-                self.report({'ERROR'}, "Unrecognised rotation parametrization")
+                message = "Unrecognised rotation parametrization"
+                self.report({'ERROR'}, message)
+                logging.error(message)
             
             obj.select = False
 
@@ -246,7 +252,9 @@ class Tools_OT_MBDyn_Animate_Eigenmode(bpy.types.Operator):
                 anim_nodes.append(node.name)
 
         if not(anim_nodes):
-            self.report({'ERROR'}, "Import nodes first")
+            message = "Import nodes first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
     
         wm.progress_begin(1, len(anim_nodes))

--- a/elements.py
+++ b/elements.py
@@ -29,6 +29,8 @@ from bpy.props import *
 from bpy_extras.io_utils import ImportHelper
 from bpy.app.handlers import persistent
 
+import logging
+
 from mathutils import *
 from math import *
 
@@ -210,8 +212,10 @@ class Scene_OT_MBDyn_Import_Elements_as_Mesh(bpy.types.Operator):
                 try:
                     verts.append(bpy.data.objects[nd[node].blender_object].location)
                 except KeyError:
-                    self.report({'ERROR'}, "Could not find Blender Objects for " + \
-                            elem.name + " import")
+                    message = "Could not find Blender Objects for " + \
+                            elem.name + " import"
+                    self.report({'ERROR'}, message)
+                    logging.error(message)
         
         node_to_vert = dict(zip((node_set), range(len(verts))))
 
@@ -248,6 +252,8 @@ class Scene_OT_MBDyn_Import_Elements_as_Mesh(bpy.types.Operator):
 
             return {'FINISHED'}
         else:
-            self.report({'WARNING'}, "No mesh data was created")
+            message = "No mesh data was created"
+            self.report({'WARNING'}, message)
+            logging.warranty(message)
             return {'CANCELLED'}
 

--- a/forcelib.py
+++ b/forcelib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -361,25 +363,31 @@ class Scene_OT_MBDyn_Import_Structural_Absolute_Force_Element(bpy.types.Operator
             elem = ed['structural_absolute_force_' + str(self.int_label)]
             retval = spawn_structural_force_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element structural_absolute_force_"\
-                    + str(elem.int_label) + "not found")
+            message = "Element structural_absolute_force_"\
+                    + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Structural_Absolute_Force_Element class
@@ -402,25 +410,31 @@ class Scene_OT_MBDyn_Import_Structural_Follower_Force_Element(bpy.types.Operator
             elem = ed['structural_follower_force_' + str(self.int_label)]
             retval = spawn_structural_force_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element structural_follower_force_"\
-                    + str(elem.int_label) + "not found")
+            message = "Element structural_follower_force_"\
+                    + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Structural_Follower_Force_Element class
@@ -443,25 +457,31 @@ class Scene_OT_MBDyn_Import_Structural_Absolute_Couple_Element(bpy.types.Operato
             elem = ed['structural_absolute_couple_' + str(self.int_label)]
             retval = spawn_structural_couple_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element structural_absolute_couple_"\
-                    + str(elem.int_label) + "not found")
+            message = "Element structural_absolute_couple_"\
+                    + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Structural_Absolute_Couple_Element class
@@ -484,25 +504,32 @@ class Scene_OT_MBDyn_Import_Structural_Follower_Couple_Element(bpy.types.Operato
             elem = ed['structural_follower_couple_' + str(self.int_label)]
             retval = spawn_structural_couple_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
+                message = "Found the Object " + \
                     elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element structural_follower_couple_"\
-                    + str(elem.int_label) + "not found")
+            message = "Element structural_follower_couple_"\
+                    + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Structural_Follower_Couple_Element class

--- a/forcelib.py
+++ b/forcelib.py
@@ -369,15 +369,15 @@ class Scene_OT_MBDyn_Import_Structural_Absolute_Force_Element(bpy.types.Operator
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -416,15 +416,15 @@ class Scene_OT_MBDyn_Import_Structural_Follower_Force_Element(bpy.types.Operator
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -463,15 +463,15 @@ class Scene_OT_MBDyn_Import_Structural_Absolute_Couple_Element(bpy.types.Operato
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -504,8 +504,7 @@ class Scene_OT_MBDyn_Import_Structural_Follower_Couple_Element(bpy.types.Operato
             elem = ed['structural_follower_couple_' + str(self.int_label)]
             retval = spawn_structural_couple_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                message = "Found the Object " + \
-                    elem.blender_object + \
+                message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
                 self.report({'WARNING'}, message)
                 logging.warning(message)

--- a/nodelib.py
+++ b/nodelib.py
@@ -30,6 +30,8 @@ from bpy.types import Operator, Panel
 from bpy.props import *
 from bpy_extras.io_utils import ImportHelper
 
+import logging
+
 import ntpath, os, csv, math
 from collections import namedtuple
 
@@ -133,8 +135,10 @@ def update_label(self, context):
         ret_val = update_parametrization(obj)
 
     if ret_val == 'ROT_NOT_SUPPORTED':
-        self.report({'ERROR'}, "Rotation parametrization not supported, node " \
-            + obj.mbdyn.string_label) 
+        message = "Rotation parametrization not supported, node " \
+            + obj.mbdyn.string_label
+        self.report({'ERROR'}, message)
+        logging.error(message)
     return
 # -----------------------------------------------------------
 # end of update_label() function <-- FIXME: Duplicate? 

--- a/plotlib.py
+++ b/plotlib.py
@@ -34,6 +34,8 @@ import pygal
 import cairosvg
 import numpy as np
 
+import logging
+
 from .nodelib import *
 from .elementlib import *
 
@@ -114,7 +116,9 @@ class Scene_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
             if (mbs.plot_xrange_min >= 0) and (mbs.plot_xrange_max > mbs.plot_xrange_min):
                 config.xrange = (mbs.plot_xrange_min, mbs.plot_xrange_max)
             else:
-                self.report({'ERROR'}, 'Invalid range for abscissa')
+                message = 'Invalid range for abscissa'
+                self.report({'ERROR'}, message)
+                logging.error(message)
         chart = pygal.XY(config)
 
         # calculate autospectra and plot them
@@ -182,7 +186,9 @@ class Scene_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
         chart.x_title = "Frequency [Hz]"
 
         if not(bpy.data.is_saved):
-            self.report({'ERROR'}, "Please save current Blender file first")
+            message = "Please save current Blender file first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
  
         plot_dir = os.path.join(bpy.path.abspath('//'), "plots")
@@ -203,7 +209,9 @@ class Scene_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
         bpy.ops.image.open(filepath = outfname + ".png")
 
 
-        self.report({'INFO'}, "Variable " + varname + " autospectrum plotted")
+        message = "Variable " + varname + " autospectrum plotted"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
         
 
@@ -237,7 +245,9 @@ class Object_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
             if (mbo.plot_xrange_min >= 0) and (mbo.plot_xrange_max > mbo.plot_xrange_min):
                 config.xrange = (mbo.plot_xrange_min, mbo.plot_xrange_max)
             else:
-                self.report({'ERROR'}, 'Invalid range for abscissa')
+                message = "Invalid range for abscissa"
+                self.report({'ERROR'}, message)
+                logging.error(message)
         chart = pygal.XY(config)
 
         # calculate autospectra and plot them
@@ -306,7 +316,9 @@ class Object_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
         chart.x_title = "time [s]"
 
         if not(bpy.data.is_saved):
-            self.report({'ERROR'}, "Please save current Blender file first")
+            message = "Please save current Blender file first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
         plot_dir = os.path.join(bpy.path.abspath('//'), "plots")
         if not os.path.exists(plot_dir):
@@ -326,7 +338,9 @@ class Object_OT_MBDyn_plot_var_Sxx(bpy.types.Operator):
         bpy.ops.image.open(filepath = outfname + ".png")
 
 
-        self.report({'INFO'}, "Variable " + mbo.plot_var + " plotted")
+        message = "Variable " + mbo.plot_var + " plotted"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
 
 class Scene_OT_MBDyn_plot_var(bpy.types.Operator):
@@ -391,7 +405,9 @@ class Scene_OT_MBDyn_plot_var(bpy.types.Operator):
         chart.x_title = "time [s]"
 
         if not(bpy.data.is_saved):
-            self.report({'ERROR'}, "Please save current Blender file first")
+            message = "Please save current Blender file first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
  
         plot_dir = os.path.join(bpy.path.abspath('//'), "plots")
@@ -412,7 +428,9 @@ class Scene_OT_MBDyn_plot_var(bpy.types.Operator):
         bpy.ops.image.open(filepath = outfname + ".png")
 
 
-        self.report({'INFO'}, "Variable " + varname + " plotted")
+        message = "Variable " + varname + " plotted"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
         
 
@@ -475,7 +493,9 @@ class Object_OT_MBDyn_plot_var(bpy.types.Operator):
         chart.x_title = "time [s]"
 
         if not(bpy.data.is_saved):
-            self.report({'ERROR'}, "Please save current Blender file first")
+            message = "Please save current Blender file first"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
         plot_dir = os.path.join(bpy.path.abspath('//'), "plots")
         if not os.path.exists(plot_dir):
@@ -495,7 +515,9 @@ class Object_OT_MBDyn_plot_var(bpy.types.Operator):
         bpy.ops.image.open(filepath = outfname + ".png")
 
 
-        self.report({'INFO'}, "Variable " + mbo.plot_var + " plotted")
+        message = "Variable " + mbo.plot_var + " plotted"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
 
 ## Simple operator to set plot frequency for object

--- a/revjlib.py
+++ b/revjlib.py
@@ -264,21 +264,21 @@ class Scene_OT_MBDyn_Import_Revolute_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -382,21 +382,21 @@ class Scene_OT_MBDyn_Import_Revolute_Pin_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object "+\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not "+\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/revjlib.py
+++ b/revjlib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -256,28 +258,36 @@ class Scene_OT_MBDyn_Import_Revolute_Joint_Element(bpy.types.Operator):
             elem = ed['revolute_hinge_' + str(self.int_label)]
             retval = spawn_revolute_hinge_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element revolute_hinge_" + str(elem.int_label) + "not found")
+            message = "Element revolute_hinge_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Revolute_Joint_Element class
@@ -366,29 +376,37 @@ class Scene_OT_MBDyn_Import_Revolute_Pin_Joint_Element(bpy.types.Operator):
             elem = ed['revolute_pin_' + str(self.int_label)]
             retval = spawn_revolute_pin_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
 
         except KeyError:
-            self.report({'ERROR'}, "Element revolute_pin_" + str(elem.int_label) + "not found")
+            message = "Element revolute_pin_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Revolute_Pin_Joint_Element class

--- a/rodjlib.py
+++ b/rodjlib.py
@@ -347,15 +347,15 @@ class Scene_OT_MBDyn_Import_Rod_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -392,19 +392,19 @@ class Scene_OT_MBDyn_Import_Rod_Bezier_Joint_Element(bpy.types.Operator):
                 message = "Found the Object " + elem.blender_object + \
                 " remove or rename it to re-import the element!"
                 self.report({'WARNING'}, message)
-                print("Element is already imported. Remove it or rename it \
-                    before re-importing the element.")
+                print("Element is already imported. Remove it or rename it " +\
+                    "before re-importing the element.")
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                associated to Node " + str(elem.nodes[0].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                "associated to Node " + str(elem.nodes[0].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/rodjlib.py
+++ b/rodjlib.py
@@ -23,6 +23,9 @@
 # -------------------------------------------------------------------------- 
 
 import bpy
+
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -338,25 +341,31 @@ class Scene_OT_MBDyn_Import_Rod_Joint_Element(bpy.types.Operator):
             elem = ed['rod_' + str(self.int_label)]
             retval = spawn_rod_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
 
         except KeyError:
-            self.report({'ERROR'}, "Element rod_" + str(elem.int_label) + "not found.")
+            message = "Element rod_" + str(elem.int_label) + "not found."
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
             
         return {'FINISHED'}
@@ -380,23 +389,31 @@ class Scene_OT_MBDyn_Import_Rod_Bezier_Joint_Element(bpy.types.Operator):
             elem = ed['rod_bezier_' + str(self.int_label)]
             retval = spawn_rod_bezier_element(elem)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + elem.blender_object + \
-                " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
                 print("Element is already imported. Remove it or rename it \
                     before re-importing the element.")
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                associated to Node " + str(elem.nodes[0].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                associated to Node " + str(elem.nodes[0].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element rod_bezier_" + str(self.int_label) + " not found.")
+            message = "Element rod_bezier_" + str(self.int_label) + " not found."
+            self.report({'ERROR'}, message)
+            logging.error(message)
 
             return {'CANCELLED'}
 # -----------------------------------------------------------
@@ -451,8 +468,10 @@ class RodWrite(Operator):
         rbtext.write("\t\t\t" + str(f2[2]) + ",\n")
         rbtext.write("\tfrom nodes;")
 
-        self.report({'INFO'}, "Input file contribute for element written. See " +\
-                        rbtext.name + " in text editor")
+        message = "Input file contribute for element written. See " +\
+                        rbtext.name + " in text editor"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
 # -----------------------------------------------------------
 # end of RodWrite class
@@ -512,8 +531,10 @@ class RodBezierWrite(Operator):
         rbtext.write("\t\t\t" + str(fI[2]) + "*msfz" + ",\n")
         rbtext.write("\tfrom nodes;")
 
-        self.report({'INFO'}, "Input file contribute for element written. See " +\
-                        rbtext.name + " in text editor")
+        message = "Input file contribute for element written. See " +\
+                        rbtext.name + " in text editor"
+        self.report({'INFO'}, message)
+        logging.info(message)
         return {'FINISHED'}
 # -----------------------------------------------------------
 # end of RodBezierWrite class

--- a/shell4lib.py
+++ b/shell4lib.py
@@ -23,6 +23,9 @@
 # -------------------------------------------------------------------------- 
 
 import bpy, bmesh
+
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -225,26 +228,38 @@ class Scene_OT_MBDyn_Import_Shell4_Element(bpy.types.Operator):
             elem = ed['shell4_' + str(self.int_label)]
             ret_val = spawn_shell4_element(elem, context)
             if ret_val == {'OBJECT_EXISTS'}:
-                self.report({'ERROR'}, "Element is already imported. Remove the Blender object before re-importing")
+                message = "Element is already imported. Remove the Blender object before re-importing"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return{'CANCELLED'}
             elif ret_val == {'NODE1_NOTFOUND'}:
-                self.report({'ERROR'}, "Could not find a Blender object associated to Node " \
-                        + str(elem.nodes[0].int_label))
+                message = "Could not find a Blender object associated to Node " \
+                        + str(elem.nodes[0].int_label)
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return{'CANCELLED'}
             elif ret_val == {'NODE2_NOTFOUND'}:
-                self.report({'ERROR'}, "Could not find a Blender object associated to Node " \
-                        + str(elem.nodes[1].int_label))
+                message = "Could not find a Blender object associated to Node " \
+                        + str(elem.nodes[1].int_label)
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return{'CANCELLED'}
             elif ret_val == {'NODE3_NOTFOUND'}:
-                self.report({'ERROR'}, "Could not find a Blender object associated to Node " \
-                        + str(elem.nodes[2].int_label))
+                message = "Could not find a Blender object associated to Node " \
+                        + str(elem.nodes[2].int_label)
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return{'CANCELLED'}
             elif ret_val == {'NODE4_NOTFOUND'}:
-                self.report({'ERROR'}, "Could not find a Blender object associated to Node " \
-                        + str(elem.nodes[3].int_label))
+                message = "Could not find a Blender object associated to Node " \
+                        + str(elem.nodes[3].int_label)
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return{'CANCELLED'}
             else:
                 return ret_val
         except KeyError:
-            self.report({'ERROR'}, "Element shell4_" + str(elem.int_label) + "not found")
+            message = "Element shell4_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}

--- a/shell4lib.py
+++ b/shell4lib.py
@@ -228,7 +228,8 @@ class Scene_OT_MBDyn_Import_Shell4_Element(bpy.types.Operator):
             elem = ed['shell4_' + str(self.int_label)]
             ret_val = spawn_shell4_element(elem, context)
             if ret_val == {'OBJECT_EXISTS'}:
-                message = "Element is already imported. Remove the Blender object before re-importing"
+                message = "Element is already imported. Remove the Blender " +\
+                            "object before re-importing"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return{'CANCELLED'}

--- a/sphjlib.py
+++ b/sphjlib.py
@@ -23,7 +23,9 @@
 # -------------------------------------------------------------------------- 
 
 import bpy
-import os.path 
+import os.path
+
+import logging
 
 from mathutils import *
 from math import *
@@ -326,28 +328,37 @@ class Scene_OT_MBDyn_Import_Spherical_Hinge_Joint_Element(bpy.types.Operator):
             elem = ed['spherical_hinge_' + str(self.int_label)]
             retval = spawn_spherical_hinge_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
+                message = "Found the Object " + \
                     elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element spherical_hinge_" + str(elem.int_label) + "not found")
+            message = "Element spherical_hinge_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Spherical_Hinge_Joint_Element class
@@ -370,24 +381,30 @@ class Scene_OT_MBDyn_Import_Spherical_Pin_Joint_Element(bpy.types.Operator):
             elem = ed['spherical_pin_' + str(self.int_label)]
             retval = spawn_spherical_pin_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element spherical_pin_" + str(elem.int_label) + "not found")
+            message = "Element spherical_pin_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Spherical_Pin_Joint_Element class

--- a/sphjlib.py
+++ b/sphjlib.py
@@ -328,28 +328,27 @@ class Scene_OT_MBDyn_Import_Spherical_Hinge_Joint_Element(bpy.types.Operator):
             elem = ed['spherical_hinge_' + str(self.int_label)]
             retval = spawn_spherical_hinge_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                message = "Found the Object " + \
-                    elem.blender_object + \
+                message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
                 self.report({'WARNING'}, message)
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -387,15 +386,15 @@ class Scene_OT_MBDyn_Import_Spherical_Pin_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/totjlib.py
+++ b/totjlib.py
@@ -490,28 +490,27 @@ class Scene_OT_MBDyn_Import_Total_Joint_Element(bpy.types.Operator):
             elem = ed['total_joint_' + str(self.int_label)]
             retval = spawn_total_joint_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                message = "Found the Object " + \
-                    elem.blender_object + \
+                message = "Found the Object " + elem.blender_object + \
                     " remove or rename it to re-import the element!"
                 self.report({'WARNING'}, message)
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                message = "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                message = "Could not import element: Blender object " +\
+                        "associated to Node " + str(elem.nodes[1].int_label) + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
@@ -882,15 +881,15 @@ class Scene_OT_MBDyn_Import_Total_Pin_Joint_Element(bpy.types.Operator):
                 logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                message = "Could not import element: Blender object \
-                    associated to Node " + str(elem.nodes[0].int_label) \
+                message = "Could not import element: Blender object " +\
+                    "associated to Node " + str(elem.nodes[0].int_label) \
                     + " not found"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                message = "Could not import element: could not \
-                        load library object"
+                message = "Could not import element: could not " +\
+                        "load library object"
                 self.report({'ERROR'}, message)
                 logging.error(message)
                 return {'CANCELLED'}

--- a/totjlib.py
+++ b/totjlib.py
@@ -25,6 +25,8 @@
 import bpy
 import os
 
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -488,28 +490,37 @@ class Scene_OT_MBDyn_Import_Total_Joint_Element(bpy.types.Operator):
             elem = ed['total_joint_' + str(self.int_label)]
             retval = spawn_total_joint_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
+                message = "Found the Object " + \
                     elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'NODE2_NOTFOUND':
-                self.report({'ERROR'}, "Could not import element: Blender object \
-                        associated to Node " + str(elem.nodes[1].int_label) + " not found")
+                message = "Could not import element: Blender object \
+                        associated to Node " + str(elem.nodes[1].int_label) + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element total_joint_" + str(elem.int_label) + "not found")
+            message = "Element total_joint_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Total_Joint_Element class
@@ -865,24 +876,30 @@ class Scene_OT_MBDyn_Import_Total_Pin_Joint_Element(bpy.types.Operator):
             elem = ed['total_pin_joint_' + str(self.int_label)]
             retval = spawn_total_pin_joint_element(elem, context)
             if retval == 'OBJECT_EXISTS':
-                self.report({'WARNING'}, "Found the Object " + \
-                    elem.blender_object + \
-                    " remove or rename it to re-import the element!")
+                message = "Found the Object " + elem.blender_object + \
+                    " remove or rename it to re-import the element!"
+                self.report({'WARNING'}, message)
+                logging.warning(message)
                 return {'CANCELLED'}
             elif retval == 'NODE1_NOTFOUND':
-                self.report({'ERROR'}, \
-                    "Could not import element: Blender object \
+                message = "Could not import element: Blender object \
                     associated to Node " + str(elem.nodes[0].int_label) \
-                    + " not found")
+                    + " not found"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             elif retval == 'LIBRARY_ERROR':
-                self.report({'ERROR'}, "Could not import element: could not \
-                        load library object")
+                message = "Could not import element: could not \
+                        load library object"
+                self.report({'ERROR'}, message)
+                logging.error(message)
                 return {'CANCELLED'}
             else:
                 return retval
         except KeyError:
-            self.report({'ERROR'}, "Element total_pin_joint_" + str(elem.int_label) + "not found")
+            message = "Element total_pin_joint_" + str(elem.int_label) + "not found"
+            self.report({'ERROR'}, message)
+            logging.error(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_Import_Total_Pin_Joint_Element class

--- a/utilslib.py
+++ b/utilslib.py
@@ -24,6 +24,9 @@
 
 # TODO: check for unnecessary stuff
 import bpy
+
+import logging
+
 from mathutils import *
 from math import *
 from bpy.types import Operator, Panel
@@ -79,7 +82,9 @@ class Object_OT_MBDyn_load_section(bpy.types.Operator, ImportHelper):
                         if jj != kk:
                             obj.layers[jj] = False
                 except IndexError:
-                    self.report({'INFO'}, "Couldn't find an empty layer. Using the active layer")
+                    message = "Couldn't find an empty layer. Using the active layer"
+                    self.report({'INFO'}, message)
+                    logging.info(message)
                     pass
                 
                 # context.curve.bevel_object = obj
@@ -93,10 +98,14 @@ class Object_OT_MBDyn_load_section(bpy.types.Operator, ImportHelper):
 
                 return {'FINISHED'}
         except IOError:
-           self.report({'ERROR'}, {'Could not locate file'})
+           message = 'Could not locate file'
+           self.report({'ERROR'}, message)
+           logging.error(message)
            return {'CANCELLED'}
         except StopIteration:
-            self.report({'WARNING'}, {'Reached the end of file'})
+            message = 'Reached the end of file'
+            self.report({'WARNING'}, message)
+            logging.warning(message)
             return {'CANCELLED'}
 # -----------------------------------------------------------
 # end of fmin function Object_OT_MBDyn_load_section class


### PR DESCRIPTION
It took me longer than expected, but it turned out to be straightforward in the end. (Because of the hierarchy of all the files in Blendyn is top down from `base.py`, the `logging` instance created in `base.py` works for all the report messages in all the modules)

I have kept the extension of the report file to be created as `.err` for the time being. Do suggest a suitable extension for the same. 

This is how report messages are stored in the log file.
```
Sun, 07 May 2017 12:54:29 - ERROR - The .log file selected does not contain MBDyn nodes definitions
Sun, 07 May 2017 12:54:40 - ERROR - MBDyn labels file not found...
Sun, 07 May 2017 12:54:45 - INFO - Scene MBDyn data cleared.
```