### PR TITLE
Add Standard import Operator

### DIFF
--- a/base.py
+++ b/base.py
@@ -773,9 +773,16 @@ class MBDynStandardImport(bpy.types.Operator):
     bl_label = "MBDyn Standard Import"
 
     def execute(self, context):
-        bpy.ops.animate.read_mbdyn_log_file('EXEC_DEFAULT')
-        bpy.ops.add.mbdynnode_all('EXEC_DEFAULT')
-        bpy.ops.add.mbdyn_elems_all('EXEC_DEFAULT')
+        try:
+            bpy.ops.animate.read_mbdyn_log_file('EXEC_DEFAULT')
+            bpy.ops.add.mbdynnode_all('EXEC_DEFAULT')
+            bpy.ops.add.mbdyn_elems_all('EXEC_DEFAULT')
+        except RuntimeError as re:
+            message = "StandardImport: something went wrong during the automatic import. "\
+                + " See the .bylog file for details"
+            self.report({'ERROR'}, message)
+            baseLogger.error(message)
+            return {'CANCELLED'}
         return {'FINISHED'}
 
     def invoke(self, context, event):

--- a/base.py
+++ b/base.py
@@ -767,6 +767,25 @@ def rename_log(scene):
 
 bpy.app.handlers.save_post.append(rename_log)
 
+class MBDynStandardImport(bpy.types.Operator):
+    """ Standard Import Process """
+    bl_idname = "animate.standard_import"
+    bl_label = "MBDyn Standard Import"
+
+    def execute(self, context):
+        bpy.ops.animate.read_mbdyn_log_file('EXEC_DEFAULT')
+        bpy.ops.add.mbdynnode_all('EXEC_DEFAULT')
+        bpy.ops.add.mbdyn_elems_all('EXEC_DEFAULT')
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
+bpy.utils.register_class(MBDynStandardImport)
+# -----------------------------------------------------------
+# end of MBDynStandardImport class
+
+
 class MBDynReadLog(bpy.types.Operator):
     """ Imports MBDyn nodes and elements by parsing the .log file """
     bl_idname = "animate.read_mbdyn_log_file"
@@ -1275,6 +1294,10 @@ class MBDynImportPanel(bpy.types.Panel):
         col = layout.column(align = True)
         col.operator(MBDynSelectOutputFile.bl_idname, text = "Select results file")
 
+        row = layout.row()
+        row.label(text = "MBDyn Standard Import")
+        col = layout.column(align = True)
+        col.operator(MBDynStandardImport.bl_idname, text = "Standard Import")
         # Display MBDyn file basename and info
         row = layout.row()
 

--- a/base.py
+++ b/base.py
@@ -521,6 +521,15 @@ class MBDynSettingsScene(bpy.types.PropertyGroup):
             name = "Elements to import",
             )
 
+    elem_scale_slider = FloatProperty(
+            name = 'Value of scaling',
+            default = 1.0
+    )
+
+    elem_type_scale = EnumProperty(
+            items = get_elems_types,
+            name = "Elements to scale",
+    )
     # Lower limit of range import for elemens
     min_elem_import = IntProperty(
             name = "first element to import",
@@ -1754,6 +1763,15 @@ class MBDynElemsScenePanel(bpy.types.Panel):
 
             col = layout.column()
             col.operator(Scene_OT_MBDyn_Elements_Import_All.bl_idname)
+
+            box = layout.box()
+            box.label(text = 'Scale MBDyn elements')
+            row = box.row()
+            row.prop(mbs, "elem_type_scale")
+            row = box.row()
+            row.prop(mbs, "elem_scale_slider")
+            row = box.row()
+            row.operator(Scene_OT_MBDyn_Scale_Elements_by_Type.bl_idname, text = "Scale Elements")
 # -----------------------------------------------------------
 # end of MBDynNodesScenePanel class
 
@@ -1977,6 +1995,21 @@ class Scene_OT_MBDyn_References_Import_Single(bpy.types.Operator):
 # -----------------------------------------------------------
 # end of Scene_OT_MBDyn_References_Import_Single class
 
+
+class Scene_OT_MBDyn_Scale_Elements_by_Type(bpy.types.Operator):
+    bl_idname = "add.mbdyn_scale_type"
+    bl_label = "Scale all elements of selected type"
+
+    def execute(self, context):
+        mbs = context.scene.mbdyn
+        ed = mbs.elems
+        s = mbs.elem_scale_slider
+        for elem in ed:
+            if elem.type == mbs.elem_type_scale:
+                scaleOBJ = bpy.data.objects[elem.name]
+                scaleOBJ.scale = Vector((s, s, s))
+
+        return {'FINISHED'}
 
 class Scene_OT_MBDyn_Import_Elements_by_Type(bpy.types.Operator):
     bl_idname = "add.mbdyn_elems_type"


### PR DESCRIPTION
Why is the default value of `max_elem_import` set at `2**31 - 1`?
I tried to set it in a similar way to `max_node_import` in #22 .