### PR TITLE
Solving Packaging

### DIFF
--- a/base.py
+++ b/base.py
@@ -1329,7 +1329,7 @@ class MBDynImportPanel(bpy.types.Panel):
 
         col = layout.column(align = True)
         col.prop(mbs, "install_packages", text = "Python Directory")
-        col.operator(MBDynInstallPackages.bl_idname, text = "Install Packages")
+        col.operator(MBDynInstallPackages.bl_idname, text = "Set Packages Path")
 
         col = layout.column(align = True)
         col.operator(MBDynSelectOutputFile.bl_idname, text = "Select results file")


### PR DESCRIPTION
This is similar to setting MBDyn's installation path, and storing it in a config.json

I store the directory of whatever directory the user usually installs his Python modules into. (usually a 
`site-packages`), into another variable 'python_path' in the same config.json file we use for the MBDyn installation path.
Doing a simple, (mbs.install_packages is the variable holding the python path)
```
import sys
sys.path.append(mbs.install_packages)
```
exposes all the modules in that directory to Blender.

For example, my default python modules directory is 
`/home/janga1997/miniconda3/lib/python3.6/site-packages/`