### PR TITLE
fixing interpretation of mathutils::Euler

### DIFF
--- a/nodelib.py
+++ b/nodelib.py
@@ -64,10 +64,10 @@ def set_obj_locrot_mov(obj, rw):
     parametrization = dictobj.parametrization
 
     if parametrization[0:5] == 'EULER':
-        obj.rotation_euler = Euler(Vector(( radians(rw[4]),\
-                                            radians(rw[5]),\
-                                            radians(rw[6]))),\
-                     axes[parametrization[7]] + axes[parametrization[6]] + axes[parametrization[5]])
+        obj.rotation_euler = Euler(Vector(( radians(float(rw[3 + int(par[5])])),\
+                                            radians(float(rw[3 + int(par[6])])),\
+                                            radians(float(rw[3 + int(par[7])])))),\
+                     axes[parametrization[5]] + axes[parametrization[6]] + axes[parametrization[7]])
         obj.keyframe_insert(data_path = "rotation_euler")
     elif parametrization == 'PHI':
         rotvec = Vector((rw[4], rw[5], rw[6]))
@@ -148,8 +148,8 @@ def parse_node(context, rw):
             return R.to_quaternion(), 'MATRIX'
         elif type[0:5] == 'euler':
             try:
-                angles = Euler(Vector(( radians(float(rw[7])), radians(float(rw[8])), radians(float(rw[9])) )),\
-                                axes[type[7]] + axes[type[6]] + axes[type[5]])
+                angles = Euler(Vector(( radians(float(rw[6+int(type[5])])), radians(float(rw[6+int(type[6])])), radians(float(rw[6+int(type[7])])) )),\
+                                axes[type[5]] + axes[type[6]] + axes[type[7]])
                 return angles.to_quaternion(), 'EULER' + type[5:8]
             except ValueError as e:
                 raise RotKeyError("BLENDYN::parse_node(): " + str(e))

--- a/rfmlib.py
+++ b/rfmlib.py
@@ -78,10 +78,10 @@ def set_ref_rotation(ref, rw, par):
         idx += 3;
         ref.rot = Quaternion(phi.normalized(), phi.magnitude)
     elif (par[0:5] == 'EULER'):
-        ref.rot = Euler(Vector((radians(float(rw[idx + 1])),\
-                                radians(float(rw[idx + 2])),\
-                                radians(float(rw[idx + 3])) )),\
-                                axes[par[7]] + axes[par[6]] + axes[par[5]]\
+        ref.rot = Euler(Vector((radians(float(rw[idx + int(par[5])])),\
+                                radians(float(rw[idx + int(par[6])])),\
+                                radians(float(rw[idx + int(par[7])])) )),\
+                                axes[par[5]] + axes[par[6]] + axes[par[7]]\
                         ).to_quaternion()
         idx += 3
     elif (par == 'MATRIX'):


### PR DESCRIPTION
It is my understanding that [the mathutils::Euler](https://docs.blender.org/api/current/mathutils.html?highlight=mathutils#mathutils.Euler) function expects the angles to be given in the same order as the string (ie: XYZ, ZYX, etc) which follows it. The later should, however, be in the "intuitive" order (instead of reversed).
I have not tempered with two other files that are likely to have the same issue and they are:
_./baselib.py, line 1015
./eigenlib.py, line 209_
It might be worth giving a look into them as well...
I tested with both euler123 and euler321 for both nodes and reference frames and it seems to hold.